### PR TITLE
Don't leave user's shell with "set -euo pipefail"

### DIFF
--- a/setup_dcs.sh
+++ b/setup_dcs.sh
@@ -1,5 +1,8 @@
-#!/usr/bin/env bash
-set -euo pipefail
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]
+then
+    echo "Hey, you should source this script, not execute it!"
+    exit 1
+fi
 
 export EPICS_BASE=$PWD/epics-base_v3.15.7
 export EPICS_HOST_ARCH=`$EPICS_BASE/startup/EpicsHostArch`


### PR DESCRIPTION
Since this script is to be sourced, not executed, remove the shebang, don't set -euo pipefail, and add something to check if script was indeed sourced.